### PR TITLE
Add negative test for find_supertype_module

### DIFF
--- a/test/testmain.jl
+++ b/test/testmain.jl
@@ -145,6 +145,9 @@ end
     # Test for same-module supertype
     @test Inherit.find_supertype_module(M2.Orange, Inherit.TypeIdentifier(((:Main, :M2), :Fruit))) === M2
     @test Inherit.find_supertype_module(M1.Orange, Inherit.TypeIdentifier(((:Main, :M1), :Fruit))) === M1
+
+    # Test for type that is not a subtype of the specified supertype
+    @test_throws ErrorException Inherit.find_supertype_module(M2.Orange, Inherit.TypeIdentifier(((:Main, :M1), :Fruit)))
 end
 
 @testset "additional M1 and M2 tests" begin


### PR DESCRIPTION
## Summary
- add failing case for `find_supertype_module` when provided a non-subtype

## Testing
- `julia --project=. test/runtests.jl` *(fails: command not found: julia)*

------
https://chatgpt.com/codex/tasks/task_e_689899adc764832ca89c91ed04f5b1d0