### PR TITLE
Fix error message for missing supertypes

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -473,10 +473,10 @@ function find_supertype_module(currenttype::Type{T}, identS::TypeIdentifier)::Mo
 		@debug "found supertype $ctmod.$ctname"
 		return ctmod
 	else
-		st = supertype(currenttype)
-		if st === Any
-			error("$identS is not a supertype of $basetype")
-		end
-		return find_supertype_module(st, identS)
-	end
+                st = supertype(currenttype)
+                if st === Any
+                        error("$identS is not a supertype of $currenttype")
+                end
+                return find_supertype_module(st, identS)
+        end
 end

--- a/test/testmain.jl
+++ b/test/testmain.jl
@@ -145,6 +145,16 @@ end
     # Test for same-module supertype
     @test Inherit.find_supertype_module(M2.Orange, Inherit.TypeIdentifier(((:Main, :M2), :Fruit))) === M2
     @test Inherit.find_supertype_module(M1.Orange, Inherit.TypeIdentifier(((:Main, :M1), :Fruit))) === M1
+
+    # Test error path when supertype is not found
+    err = try
+        Inherit.find_supertype_module(M2.Orange1, Inherit.TypeIdentifier(((:Main, :M3), :Fruit)))
+        nothing
+    catch err
+        err
+    end
+    @test err isa ErrorException
+    @test occursin("M2.Orange1", err.msg)
 end
 
 @testset "additional M1 and M2 tests" begin


### PR DESCRIPTION
## Summary
- reference the current type in `find_supertype_module` error messages
- test the error case when the requested supertype cannot be found

## Testing
- `julia --project -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898998a80cc832c97056353f7d84efd