### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The environment setup README is [here](file:///README_setup.md)
 
 Inherit.jl is used to inherit fields and interface definitions from a supertype. It supports programming with an **object-oriented flavor** in Julia, whenever this is more appropriate than developing under traditional Julia patterns. 
 
-**Fields** defined in a supertype are automatically inherited by each subtype, and **method declarations** are checked for each subtype's implementation. An **inheritance hierachy** across multiple modules is supported. To accomplish this, macro processing is used to construct **native Julia types**, which allows the the full range of Julia syntax to be used in most situations.
+**Fields** defined in a supertype are automatically inherited by each subtype, and **method declarations** are checked for each subtype's implementation. An **inheritance hierarchy** across multiple modules is supported. To accomplish this, macro processing is used to construct **native Julia types**, which allows the the full range of Julia syntax to be used in most situations.
 
 # Quick Start
 


### PR DESCRIPTION
## Summary
- fix typo in README: change "inheritance hierachy" to "inheritance hierarchy"

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68989994ff5c832cad74106f6fe20689