### PR TITLE
Fix import expression builder to use symbols directly

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -457,12 +457,10 @@ expr = build_import_expr(:PkgTest1, :PkgTest2, :DataFrames)
 ```
 """
 function build_import_expr(pkgnames::Symbol...)::Expr
-    if length(pkgnames) == 0
+    if isempty(pkgnames)
         throw(ArgumentError("At least one package name must be provided"))
     end
-    # Each package name needs to be wrapped in Expr(:., symbol) for proper import syntax
-    import_args = [Expr(:., pkg) for pkg in pkgnames]
-    Expr(:import, import_args...)
+    Expr(:import, pkgnames...)
 end
 
 function find_supertype_module(currenttype::Type{T}, identS::TypeIdentifier)::Module where T

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -153,26 +153,22 @@ and properly handles edge cases like empty input
     expr1 = Inherit.build_import_expr(:PkgTest1)
     @test expr1.head == :import
     @test length(expr1.args) == 1
-    @test expr1.args[1] isa Expr
-    @test expr1.args[1].head == :.
-    @test expr1.args[1].args[1] == :PkgTest1
+    @test expr1.args[1] == :PkgTest1
     
     # Test multiple package import
     expr2 = Inherit.build_import_expr(:PkgTest1, :PkgTest2, :DataFrames)
     @test expr2.head == :import
     @test length(expr2.args) == 3
-    @test all(arg isa Expr && arg.head == :. for arg in expr2.args)
-    @test expr2.args[1].args[1] == :PkgTest1
-    @test expr2.args[2].args[1] == :PkgTest2
-    @test expr2.args[3].args[1] == :DataFrames
+    @test expr2.args[1] == :PkgTest1
+    @test expr2.args[2] == :PkgTest2
+    @test expr2.args[3] == :DataFrames
     
     # Test two package import
     expr3 = Inherit.build_import_expr(:Foo, :Bar)
     @test expr3.head == :import
     @test length(expr3.args) == 2
-    @test all(arg isa Expr && arg.head == :. for arg in expr3.args)
-    @test expr3.args[1].args[1] == :Foo
-    @test expr3.args[2].args[1] == :Bar
+    @test expr3.args[1] == :Foo
+    @test expr3.args[2] == :Bar
     
     # Test error on empty input
     @test_throws ArgumentError Inherit.build_import_expr()
@@ -180,7 +176,7 @@ and properly handles edge cases like empty input
     # Test that expressions can be evaluated (syntactically valid)
     for expr in [expr1, expr2, expr3]
         @test Meta.isexpr(expr, :import)
-        @test all(Meta.isexpr(arg, :.) for arg in expr.args)
+        @test all(arg isa Symbol for arg in expr.args)
     end
     
     # Test equivalence to literal import expressions


### PR DESCRIPTION
## Summary
- Correct `build_import_expr` to build `import` expressions using package symbols directly
- Update tests accordingly

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: bash: command not found: julia)*

------
https://chatgpt.com/codex/tasks/task_e_689897374e9c832cb8f6f347de772193