### PR TITLE
Add coverage workflow for Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,23 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests with coverage and upload results to Codecov

## Testing
- `julia +1.12 --project=. test/runtests.jl`
- `julia +1.11 --project=. test/runtests.jl`
- `julia +1.10 --project=. test/runtests.jl`


------
https://chatgpt.com/codex/tasks/task_e_6899191515a4832cbbcf536fa379214d