### PR TITLE
fix: update pages deploy workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './docs/build'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- update GitHub Pages workflow to avoid deprecated artifact action

## Testing
- `julia +1.12 --project=. test/runtests.jl`
- `julia +1.11 --project=. test/runtests.jl`
- `julia +1.10 --project=. test/runtests.jl`


------
https://chatgpt.com/codex/tasks/task_e_689924718e88832ca92e4ddc0f308833