### PR TITLE
fix: build docs in pages workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/checkout@v4
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v1
         with:
-          # Upload entire repository
+          version: '1'
+      - name: Install dependencies
+        run: |
+          julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); Pkg.instantiate()'
+      - name: Build docs
+        run: julia --project=docs docs/make.jl
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
           path: './docs/build'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Inherit = "341b8389-5eed-42ab-a01e-622c6bedf032"
+
+[compat]
+Documenter = "1"


### PR DESCRIPTION
## Summary
- run `docs/make.jl` in GitHub Pages workflow
- add doc-specific project with Documenter dependency

## Testing
- `julia --project=docs docs/make.jl`
- `ls docs/build`


------
https://chatgpt.com/codex/tasks/task_e_689924718e88832ca92e4ddc0f308833